### PR TITLE
Remove Home Assistant

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,8 +9,8 @@
 #include <cstdio>
 
 // TODO
-// remove mqtt.
 // remove wifi.
+// remove home assistant.
 // ensure multiple devices can connect.
 // wait until the intended number of devices are connected before proceeding.
 // proceed to be a peripheral for xLights (somehow).
@@ -52,7 +52,6 @@ struct LightDevice
   uint8_t type[2];
   bool isRegistered = false;
   std::string id;
-  HALight *light;
   std::string name;
   uint8_t number;
 };
@@ -571,40 +570,6 @@ class AddLightCallback : public BLEAdvertisedDeviceCallbacks
                   break;
                 }
               }
-              // create the HA object
-              if (typeName == "RGBW")
-              {
-                HALight *light = new HALight(myLights[i].id.c_str(), HALight::BrightnessFeature | HALight::ColorTemperatureFeature | HALight::RGBFeature);
-                light->setName(myLights[i].name.c_str());
-                light->onStateCommand(onStateCommand);
-                light->onBrightnessCommand(onBrightnessCommand);
-                light->onColorTemperatureCommand(onColorTemperatureCommand);
-                light->onRGBColorCommand(onRGBColorCommand);
-                light->setBrightnessScale(127);
-                light->setBrightness(127);
-                myLights[i].light = light;
-              }
-              else if (typeName == "RGB")
-              {
-                HALight *light = new HALight(myLights[i].id.c_str(), HALight::BrightnessFeature | HALight::RGBFeature);
-                light->setName(myLights[i].name.c_str());
-                light->onStateCommand(onStateCommand);
-                light->onBrightnessCommand(onBrightnessCommand);
-                light->onRGBColorCommand(onRGBColorCommand);
-                light->setBrightnessScale(127);
-                light->setBrightness(127);
-                myLights[i].light = light;
-              }
-              else
-              {
-                // "Smart" - no additional features
-                HALight *light = new HALight(myLights[i].id.c_str());
-                light->setName(myLights[i].name.c_str());
-                light->onStateCommand(onStateCommand);
-                myLights[i].light = light;
-              }
-              Serial.printf(", created light ");
-              Serial.printf(myLights[i].light->uniqueId());
             }
             Serial.println("");
           }
@@ -711,6 +676,7 @@ void setup()
   pAdvertising = BLEDevice::getAdvertising();
   BLEDevice::startAdvertising();
   WiFi.begin(WIFI_SSID, WIFI_PASS);
+  // TODO: delete
   while (WiFi.status() != WL_CONNECTED)
   {
     delay(500); // waiting for the connection
@@ -719,12 +685,12 @@ void setup()
   // add the lights
   addLights();
   // print the added lights with their IDs
+  Serial.println("added lights on setup:");
   for (int i = 0; i < myLights.size(); i++)
   {
     if (myLights[i].isRegistered)
     {
-      Serial.printf("Light %d - ", myLights[i].number);
-      Serial.println(myLights[i].light->uniqueId());
+      Serial.printf("Light %d\n", myLights[i].number);
     }
   }
   randomSeed(analogRead(0)); // set random seed

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -724,23 +724,19 @@ void setup()
   mqtt->publish("lights-status", "ESP32 Joined");
 }
 
-HALight::RGBColor getRandomColor()
-{
-  return {random(255), random(255), random(255)};
-}
-
 void loop()
 {
-  auto color = getRandomColor();
+  static bool state = true;
   for (auto light : myLights)
   {
     uint8_t data[] = {0x72, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00};
     data[1] = light.number;
-    data[2] = 127;
-    data[3] = color.blue;
-    data[4] = color.red;
-    data[5] = color.green;
+    data[2] = state ? 255 : 0;
+    data[3] = 0;   // blue
+    data[4] = 0;   // red
+    data[5] = 255; // green
     single_control(my_key, data);
   }
+  state = !state;
   delay(3000);
 }


### PR DESCRIPTION
This PR removes Home Assistant, MQTT, and Wi-Fi

It has been tested with one light, but fails with two lights.

I see this log:

```
BLE Device found -> Address: 11:22:33:44:55:66, Name: , RSSI: -48, Manufacturer Data: F0FF6E927A64D1B9A2A8A18DA8A3A5B8A2AC, It's one of our lights!, with the new key, clean manufacturer data: 7401000404350A0F00000000
```

My suspicion is that the lights are both being detected to have the MAC address `11:22:33:44:55:66`.

I'll try to resolve this next.